### PR TITLE
fix: wrap generator fixture yield None

### DIFF
--- a/src/lamber/main.py
+++ b/src/lamber/main.py
@@ -200,6 +200,8 @@ class Lamber:
 
             setattr(fixturedef, "_lamber_wrapped", True)
 
+        setattr(request.node, "_lamber_test_case", self.test_session.current_test_case)
+
     @hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self) -> Generator[None, None, None]:
         self.test_session.current_test_exec = self.test_session.current_test_case

--- a/src/lamber/models.py
+++ b/src/lamber/models.py
@@ -319,9 +319,9 @@ def step(
                 generator = _func(*args, **kwargs)
 
                 with TestStep(title, when=when, scope=scope):
-                    next(generator)
+                    result = next(generator)
 
-                yield
+                yield result
 
                 with TestStep(title, when=when, scope=scope):
                     try:
@@ -350,7 +350,6 @@ class AttachmentType(Enum):
     URI = ("text/uri-list", "uri")
     CSV = ("text/csv", "csv")
     XML = ("text/xml", "xml")
-    ZIP = ("application/zip", "zip")
 
     def __init__(self, mime_type: str, extension: str) -> None:
         self.mime_type = mime_type
@@ -422,9 +421,7 @@ class TestCase(TestStep):
     def sourcecode(self) -> str:
         return "\n\n".join(self.sourcecodes)
 
-    def attach(
-        self, name: str, value: any, *, type: AttachmentType = AttachmentType.TEXT
-    ):
+    def attach(self, name: str, value: any, type: AttachmentType = AttachmentType.TEXT):
         self.attachments[name] = Attachment(name, type, value)
 
 

--- a/src/lamber/sqlite.py
+++ b/src/lamber/sqlite.py
@@ -245,6 +245,7 @@ class SqlitePlugin:
                 )
             )
 
+    @pytest.hookimpl(trylast=True)
     def pytest_lamber_log_test_case_stop(
         self,
         test_case: TestCase,


### PR DESCRIPTION
* [sqlite] make `pytest_lamber_log_test_case_stop` hook `trylast=True`.
* add `_lamber_test_case` attribute for each test node.